### PR TITLE
Remove GO111MODULE and .envrc

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,4 +1,0 @@
-export GOPATH=$PWD
-export PATH=$GOPATH/bin:$PATH
-
-unset GOBIN

--- a/packages/system-metrics-plugin/packaging
+++ b/packages/system-metrics-plugin/packaging
@@ -2,7 +2,5 @@ set -ex
 
 source /var/vcap/packages/golang-1-linux/bosh/compile.env
 
-export GO111MODULE=on
-
 cd github.com/cloudfoundry/bosh-system-metrics-server/
 go build -mod=vendor -o ${BOSH_INSTALL_TARGET}/system-metrics-plugin cmd/plugin/main.go

--- a/packages/system-metrics-server/packaging
+++ b/packages/system-metrics-server/packaging
@@ -2,7 +2,5 @@ set -ex
 
 source /var/vcap/packages/golang-1-linux/bosh/compile.env
 
-export GO111MODULE=on
-
 cd github.com/cloudfoundry/bosh-system-metrics-server/
 go build -mod=vendor -o ${BOSH_INSTALL_TARGET}/system-metrics-server cmd/server/main.go


### PR DESCRIPTION
- GO111MODULE is the default in recent versions of Go