### PR TITLE
Bump to go1.21

### DIFF
--- a/packages/golang-1.20-linux/spec.lock
+++ b/packages/golang-1.20-linux/spec.lock
@@ -1,2 +1,0 @@
-name: golang-1.20-linux
-fingerprint: 8859f2c2f47d9b58d85ae101405d8af92c7d26d30231721341bc49bd657ccb4d

--- a/packages/system-metrics-plugin/packaging
+++ b/packages/system-metrics-plugin/packaging
@@ -1,6 +1,6 @@
 set -ex
 
-source /var/vcap/packages/golang-1.20-linux/bosh/compile.env
+source /var/vcap/packages/golang-1.21-linux/bosh/compile.env
 export GOPATH=/var/vcap
 
 go build -mod=vendor -o ${BOSH_INSTALL_TARGET}/system-metrics-plugin ./cmd/plugin/

--- a/packages/system-metrics-plugin/spec
+++ b/packages/system-metrics-plugin/spec
@@ -2,7 +2,7 @@
 name: system-metrics-plugin
 
 dependencies:
-- golang-1.20-linux
+- golang-1.21-linux
 
 files:
 - "**/*"

--- a/packages/system-metrics-server/packaging
+++ b/packages/system-metrics-server/packaging
@@ -1,6 +1,6 @@
 set -ex
 
-source /var/vcap/packages/golang-1.20-linux/bosh/compile.env
+source /var/vcap/packages/golang-1.21-linux/bosh/compile.env
 export GOPATH=/var/vcap
 
 go build -mod=vendor -o ${BOSH_INSTALL_TARGET}/system-metrics-server ./cmd/server/

--- a/packages/system-metrics-server/spec
+++ b/packages/system-metrics-server/spec
@@ -2,7 +2,7 @@
 name: system-metrics-server
 
 dependencies:
-- golang-1.20-linux
+- golang-1.21-linux
 
 files:
 - "**/*"

--- a/src/go.mod
+++ b/src/go.mod
@@ -1,6 +1,6 @@
 module github.com/cloudfoundry/bosh-system-metrics-server
 
-go 1.20
+go 1.21
 
 require (
 	github.com/golang/protobuf v1.5.3

--- a/src/go.sum
+++ b/src/go.sum
@@ -5,6 +5,7 @@ github.com/golang/protobuf v1.5.3 h1:KhyjKVUg7Usr/dYsdSqoFveMYd5ko72D+zANwlG1mmg
 github.com/golang/protobuf v1.5.3/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
+github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/hpcloud/tail v1.0.0 h1:nfCOvKYfkgYP8hkirhJocXT2+zOD8yUNjXaWfTlyFKI=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/onsi/ginkgo v1.6.0 h1:Ix8l273rp3QzYgXSR+c8d1fTG7UPgYkOSELPhiY/YGw=


### PR DESCRIPTION
# Description

* Removes go1.20 packages
* Uses go1.21 packages to build the other packages
* Specify go1.21 as the go version in `src/go.mod`

## Type of change

- [x] Maintenance
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] This PR is being made against the `main` branch, or relevant version branch
- [ ] I have made corresponding changes to the documentation
- [ ] I have added testing for my changes

If you have any questions, or want to get attention for a PR or issue please reach out on the [#logging-and-metrics channel in the cloudfoundry slack](https://cloudfoundry.slack.com/archives/CUW93AF3M)
