### PR TITLE
Address gosec G109 for integer overflow

### DIFF
--- a/src/pkg/unmarshal/event.go
+++ b/src/pkg/unmarshal/event.go
@@ -4,8 +4,9 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"time"
+	"math"
 	"strconv"
+	"time"
 
 	"github.com/cloudfoundry/bosh-system-metrics-server/pkg/definitions"
 )
@@ -23,7 +24,11 @@ func Event(eventJSON []byte) (*definitions.Event, error) {
 
 	switch evt.Kind {
 	case "heartbeat":
-		return mapHeartbeat(evt), nil
+		heartbeat, err := mapHeartbeat(evt)
+		if err != nil {
+			return nil, err
+		}
+		return heartbeat, nil
 	case "alert":
 		return mapAlert(evt), nil
 	default:
@@ -48,7 +53,12 @@ func mapAlert(evt event) *definitions.Event {
 	}
 }
 
-func mapHeartbeat(evt event) *definitions.Event {
+func mapHeartbeat(evt event) (*definitions.Event, error) {
+	index, err := getIndexFromString(evt)
+	if err != nil {
+		return nil, err
+	}
+
 	return &definitions.Event{
 		Id:         evt.Id,
 		Deployment: evt.Deployment,
@@ -57,18 +67,33 @@ func mapHeartbeat(evt event) *definitions.Event {
 			Heartbeat: &definitions.Heartbeat{
 				AgentId:    evt.AgentId,
 				Job:        evt.Job,
-				Index:      getIndexFromString(evt),
+				Index:      *index,
 				InstanceId: evt.InstanceId,
 				JobState:   evt.JobState,
 				Metrics:    filterMetricsWithValues(evt),
 			},
 		},
-	}
+	}, nil
 }
 
-func getIndexFromString(evt event) int32 {
-	index, _ := strconv.Atoi(evt.Index)
-	return int32(index)
+func getIndexFromString(evt event) (*int32, error) {
+	if evt.Index == "" {
+		zeroIndex := int32(0)
+		return &zeroIndex, nil
+	}
+
+	index, err := strconv.Atoi(evt.Index)
+	if err != nil {
+		return nil, err
+	}
+
+	if index > math.MaxInt32 {
+		integerOverflowError := fmt.Sprintf("integer overflow detected for casting index %d to int32", index)
+		return nil, errors.New(integerOverflowError)
+	}
+
+	int32Index := int32(index) // #nosec G109 - Checked for integer overflow above
+	return &int32Index, nil
 }
 
 func filterMetricsWithValues(evt event) []*definitions.Heartbeat_Metric {


### PR DESCRIPTION
# Description

This PR addresses the gosec rule G109 by checking for integer overflow when casting to `int32`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing performed?

- [x] Unit tests
- [x] Integration tests
- [ ] Acceptance tests

## Checklist:

- [x] This PR is being made against the `main` branch, or relevant version branch
- [x] I have made corresponding changes to the documentation
- [x] I have added testing for my changes